### PR TITLE
Fixed the flash of short height, also adds the source comment

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "build": "run-s build:wasm-terminal build:preact",
     "build:preact": "npx preact build --no-prerender",
     "build:wasm-terminal": "cpy 'node_modules/@wasmer/wasm-terminal/dist' src/assets/wasm-terminal",
-    "serve": "npx serve -p 8000 build/",
     "dev": "npx preact watch -p 8000",
+    "serve": "npx serve -p 8000 build/",
     "lint": "npx eslint src"
   },
   "eslintConfig": {

--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ export default class App extends Component {
     setTimeout(() => {
       this.wasmTerminal.fit();
       this.wasmTerminal.focus();
-    });
+    }, 16);
   }
 
   componentWillUnmount() {

--- a/src/style.css
+++ b/src/style.css
@@ -3,3 +3,8 @@ button {
   cursor: pointer;
 }
 
+#wasm-terminal, #wasm-terminal > .xterm, #wasm-terminal > .xterm-viewport, #wasm-terminal > .xterm-screen {
+  height: 100%;
+  width: 100%;
+}
+

--- a/src/template.html
+++ b/src/template.html
@@ -1,5 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
+  <!--
+    WebAssembly Shell
+    See source code in: https://github.com/wasmerio/wasm-shell
+  -->
 	<head>
 		<meta charset="utf-8">
 		<title><% preact.title %></title>
@@ -27,10 +31,6 @@
         position: fixed;
         overflow-y: scroll;
         -webkit-overflow-scrolling: touch;
-      }
-
-      #wasm-terminal, #wasm-terminal > .xterm, #wasm-terminal > .xterm-viewport, #wasm-terminal > .xterm-screen {
-        height: 100%;
       }
     </style>
 		<% preact.headEnd %>


### PR DESCRIPTION
This fixes the flash of short height. For some reason, `preact-cli` is not happy with css that is not for html or body. s we use that, and then add the terminal styles when needed.

![Screen Shot 2019-09-18 at 3 56 23 PM](https://user-images.githubusercontent.com/1448289/65192701-e19ba180-da2c-11e9-9309-c0a46797fb2d.png)
