### PR TITLE
Got the correct wasm terminal version

### DIFF
--- a/src/services/wapm/callback-commands/welcome.js
+++ b/src/services/wapm/callback-commands/welcome.js
@@ -26,10 +26,13 @@ ${magenta}       wwwwwwww
 ${magenta}           wwww              
 ${reset}`;
 
+const wasmShVersion = packageJson.version;
+const wasmerWasmTerminalVersion = packageJson.dependencies['@wasmer/wasm-terminal'].replace('^', '');
+
 let welcomeMessage = `
-${bold}WebAssembly.sh${reset} v${packageJson.version}
+${bold}WebAssembly.sh${reset} v${wasmShVersion}
 Powered by Wasmer-JS
-    @wasmer/wasm-terminal v0.1.0
+    @wasmer/wasm-terminal v${wasmerWasmTerminalVersion}
 
 QUICK START:
     • Try a command: \`cowsay hello\`.


### PR DESCRIPTION
closes #47 
relates to https://github.com/wasmerio/wasmer-js/issues/114

Adds the correct version of `@wasmer/wasm-terminal` in the welcome message 😄 

<img width="871" alt="Screen Shot 2019-10-10 at 5 48 46 PM" src="https://user-images.githubusercontent.com/1448289/66616591-4d81ad80-eb86-11e9-8a29-78cd9a5a474c.png">

