### PR TITLE
Updated to wasm-terminal 0.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wasm-shell",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -14,15 +14,15 @@
       }
     },
     "@babel/core": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.3.tgz",
-      "integrity": "sha512-QfQ5jTBgXLzJuo7Mo8bZK/ePywmgNRgk/UQykiKwEtZPiFIn8ZqE6jB+AnD1hbB1S2xQyL4//it5vuAUOVAMTw==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.4.tgz",
+      "integrity": "sha512-Rm0HGw101GY8FTzpWSyRbki/jzq+/PkNQJ+nSulrdY6gFGOsNseCqD6KHRYe2E+EdzuBdr2pxCp6s4Uk6eJ+XQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.5.5",
-        "@babel/generator": "^7.6.3",
+        "@babel/generator": "^7.6.4",
         "@babel/helpers": "^7.6.2",
-        "@babel/parser": "^7.6.3",
+        "@babel/parser": "^7.6.4",
         "@babel/template": "^7.6.0",
         "@babel/traverse": "^7.6.3",
         "@babel/types": "^7.6.3",
@@ -32,7 +32,7 @@
         "lodash": "^4.17.13",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
-        "source-map": "^0.6.1"
+        "source-map": "^0.5.0"
       },
       "dependencies": {
         "debug": {
@@ -49,33 +49,19 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
         }
       }
     },
     "@babel/generator": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.3.tgz",
-      "integrity": "sha512-hLhYbAb3pHwxjlijC4AQ7mqZdcoujiNaW7izCT04CIowHK8psN0IN8QjDv0iyFtycF5FowUOTwDloIheI25aMw==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.4.tgz",
+      "integrity": "sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.6.3",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.13",
-        "source-map": "^0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
+        "source-map": "^0.5.0"
       }
     },
     "@babel/helper-annotate-as-pure": {
@@ -317,9 +303,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.3.tgz",
-      "integrity": "sha512-sUZdXlva1dt2Vw2RqbMkmfoImubO0D0gaCrNngV6Hi0DA4x3o4mlrq0tbfY0dZEUIccH8I6wQ4qgEtwcpOR6Qg==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.4.tgz",
+      "integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==",
       "dev": true
     },
     "@babel/plugin-proposal-async-generator-functions": {
@@ -1018,12 +1004,12 @@
       }
     },
     "@hapi/topo": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.5.tgz",
-      "integrity": "sha512-bi9m1jrui9LlvtVdLaHv0DqeOoe+I8dep+nEcTgW6XxJHL3xArQcilYz3tIp0cRC4gWlsVtABK7vNKg4jzEmAA==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
+      "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
       "dev": true,
       "requires": {
-        "@hapi/hoek": "8.x.x"
+        "@hapi/hoek": "^8.3.0"
       }
     },
     "@mrmlnc/readdir-enhanced": {
@@ -1113,9 +1099,9 @@
       }
     },
     "@wasmer/wasm-terminal": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@wasmer/wasm-terminal/-/wasm-terminal-0.2.2.tgz",
-      "integrity": "sha512-Goe4aQiLlVwndcufd+viiFW7xvL45sk9sbvYIuo814Mxjvzc0M1tkeao5KrjpjOQ3Aq20DR8vJz6ZO0yFwqMOg==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@wasmer/wasm-terminal/-/wasm-terminal-0.2.3.tgz",
+      "integrity": "sha512-Uvz3BrbaoZ5x6ScUVR7cicXHOUPKrqzWahVSI57oy7UN3dRX6YZfA7dhFwsC87O2lTjXGSgWcLVat+muiS74Ng==",
       "requires": {
         "@wasmer/wasi": "^0.2.0",
         "@wasmer/wasm-transformer": "^0.1.0",
@@ -2888,9 +2874,9 @@
       }
     },
     "comlink": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.0.4.tgz",
-      "integrity": "sha512-ohwOM3f1H23rwckW4338kpWeODMPY2d5C5QgOk3VE98Jc//9GM78OjxaVdZ0raXhs97OH7w7Uuzrpk1n/b1V2Q=="
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.0.5.tgz",
+      "integrity": "sha512-A4+KdcBEDJYl39pdSFs1ZuaN+UIFuEf4bAsDnJGBf7630FvbE8LRIPb5bHIy+wl/Q5moCkNnHkX3ccREYTKVQg=="
     },
     "commander": {
       "version": "2.17.1",
@@ -4252,9 +4238,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.280",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.280.tgz",
-      "integrity": "sha512-qYWNMjKLEfQAWZF2Sarvo+ahigu0EArnpCFSoUuZJS3W5wIeVfeEvsgmT2mgIrieQkeQ0+xFmykK3nx2ezekPQ==",
+      "version": "1.3.281",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.281.tgz",
+      "integrity": "sha512-oxXKngPjTWRmXFy4vV9FeAkPl7wU4xMejfOY+HXjGrj4T0z9l96loWWVDLJEtbT/aPKOWKrSz6xoYxd+YJ/gJA==",
       "dev": true
     },
     "elliptic": {
@@ -9442,9 +9428,9 @@
       "integrity": "sha512-37tlDJGq5IQKqGUbqPZ7qPtsTOWFyxe+ojAOFfzKo0dEPreenqrqgJuS83zGpeGAqD9h9L9Yr7QuxH2W4ZrKxg=="
     },
     "preact-cli": {
-      "version": "3.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/preact-cli/-/preact-cli-3.0.0-rc.5.tgz",
-      "integrity": "sha512-lIb1XY1+XFZgxu8ELT8WdFLL6DXhOTZ8Q06BPYPWI8aQXmqi21dq6C7lMumkMYB+c1IOsoRzy8HZ08bVZlYcww==",
+      "version": "3.0.0-rc.6",
+      "resolved": "https://registry.npmjs.org/preact-cli/-/preact-cli-3.0.0-rc.6.tgz",
+      "integrity": "sha512-HJ/8WgNW23Cy74l+jRR+tOoX771xF2bpuHNXlWGi7qlM1LQLgnbgWQt5PeRtsUbSFRbe2fl6pEXDX4tMnmQrAg==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.5.5",
@@ -11780,9 +11766,9 @@
       },
       "dependencies": {
         "commander": {
-          "version": "2.20.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.1.tgz",
-          "integrity": "sha512-cCuLsMhJeWQ/ZpsFTbE765kvVfoeSddc4nU3up4fV+fDBcfUXnbITJ+JzhkdjzOqhURjZgujxaioam4RM9yGUg==",
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
           "dev": true
         },
         "source-map": {
@@ -12587,9 +12573,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.0.tgz",
-      "integrity": "sha512-yNV98U4r7wX1VJAj5kyMsu36T8RPPQntcb5fJLOsMz/pt/WrKC0Vp1bAlqPLkA1LegSwQwf6P+kAbyhRKVQ72g==",
+      "version": "4.41.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.1.tgz",
+      "integrity": "sha512-ak7u4tUu/U63sCVxA571IuPZO/Q0pZ9cEXKg+R/woxkDzVovq57uB6L2Hlg/pC8LCU+TWpvtcYwsstivQwMJmw==",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
@@ -12693,9 +12679,9 @@
           "dev": true
         },
         "commander": {
-          "version": "2.20.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.1.tgz",
-          "integrity": "sha512-cCuLsMhJeWQ/ZpsFTbE765kvVfoeSddc4nU3up4fV+fDBcfUXnbITJ+JzhkdjzOqhURjZgujxaioam4RM9yGUg==",
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "wasmerio",
     "wasmfs"
   ],
-  "version": "0.0.1",
+  "version": "0.0.2",
   "license": "MIT",
   "scripts": {
     "postinstall": "npx run-s build:wasm-terminal build:wasm-transformer",
@@ -45,7 +45,7 @@
     "serve": "^11.1.0"
   },
   "dependencies": {
-    "@wasmer/wasm-terminal": "^0.2.2",
+    "@wasmer/wasm-terminal": "^0.2.3",
     "@wasmer/wasm-transformer": "^0.2.0",
     "idb-keyval": "^3.2.0",
     "normalize.css": "^8.0.1",


### PR DESCRIPTION
Includes all of the bug fixes, notably better iOS Safari keyboard support (Also tested on my MBP and Andoird device to be working).

# Example

![wasmIos](https://user-images.githubusercontent.com/1448289/66690251-b713c180-ec43-11e9-855a-6a7d0f733c96.gif)
