### PR TITLE
Prevent double scrollbars

### DIFF
--- a/src/template.html
+++ b/src/template.html
@@ -26,6 +26,10 @@
     <meta name="apple-mobile-web-app-capable" content="yes">
     <link rel="stylesheet" type="text/css" href="/assets/wasm-terminal/xterm.css">
     <style>
+      *, *::before, *::after {
+        box-sizing: border-box;
+      }
+
       html, body {
         font: 14px/1.21 "Times New Roman", Times, serif;
         font-weight: 400;
@@ -43,7 +47,7 @@
 
       body {
         position: fixed;
-        overflow-y: scroll;
+        overflow-y: auto;
       }
     </style>
     <% preact.headEnd %>


### PR DESCRIPTION
Only show scrollbar on body when needed.
Use box-sizing to ensure padding doesn't make elements wider than 100%

Fixes https://github.com/wasmerio/webassembly.sh/issues/56