### PR TITLE
Improved param handling for integration in WAPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "build:wasm-terminal:xterm": "npx cpy 'node_modules/@wasmer/wasm-terminal/lib/xterm/**/*' src/assets/wasm-terminal",
     "build:wasm-terminal:workers": "npx cpy 'node_modules/@wasmer/wasm-terminal/lib/workers/**/*' src/assets/wasm-terminal",
     "build:wasm-transformer": "npx cpy 'node_modules/@wasmer/wasm-transformer/lib/wasm-transformer.wasm' src/assets/wasm-transformer",
-    "dev": "npx preact watch -p 8000",
-    "serve": "npx serve -p 8000 build/",
+    "dev": "npx preact watch -p 8080",
+    "serve": "npx serve -p 8080 build/",
     "lint": "npx eslint src"
   },
   "eslintConfig": {

--- a/src/index.js
+++ b/src/index.js
@@ -41,9 +41,15 @@ export default class App extends Component {
 
   componentDidMount() {
     const asyncTask = async () => {
-      await this._setupWasmTerminal();
+      let params = this._handleQueryParams();
+      await this._setupWasmTerminal(params.inline);
       this._setupDropZone();
-      this._handleQueryParams();
+      if (params.runCommand) {
+        // console.log(params.runCommand);
+        setTimeout(
+          () => this.wasmTerminal.runCommand(params.runCommand),
+        50);
+      }
     };
     asyncTask();
   }
@@ -75,10 +81,12 @@ export default class App extends Component {
     );
   }
 
-  _setupWasmTerminal() {
+  _setupWasmTerminal(isInline) {
     // Let's bind our wasm terminal to it's container
     const containerElement = document.querySelector("#wasm-terminal");
-    this.wasmTerminal.print(getWelcomeMessage());
+    if (!isInline) {
+      this.wasmTerminal.print(getWelcomeMessage());
+    }
     this.wasmTerminal.open(containerElement);
 
     let resolveOpenPromise = undefined;
@@ -177,9 +185,9 @@ export default class App extends Component {
 
   _handleQueryParams() {
     const params = new URLSearchParams(window.location.search);
-    if (params.has("run-command")) {
-      const command = params.get("run-command");
-      this.wasmTerminal.runCommand(command);
+    return {
+      runCommand: params.get("run-command"),
+      inline: params.has("inline"),
     }
   }
 }


### PR DESCRIPTION
This PR makes the following possible:
<img width="984" alt="Screen Shot 2019-12-11 at 1 26 04 PM" src="https://user-images.githubusercontent.com/188257/70661748-cf8b6280-1c19-11ea-9715-41acb5ad0f16.png">

* [x] Inline version of WebAssembly shell (without a welcome message)
* [x] Fix issue (`run-command` not running) when using iframe (solved by using a `setTimeout`)
* [x] Use port 8080 to don't collide with dev version of wapm